### PR TITLE
Setup npm publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "./node_modules/.bin/gulp serve",
     "build": "npm install && gulp build --production",
-    "deploy": "yarn && ./node_modules/.bin/gulp && ./node_modules/.bin/gulp deploy"
+    "deploy": "npm install && ./node_modules/.bin/gulp && ./node_modules/.bin/gulp deploy"
   },
   "engines": {
     "node": "6.7.0",


### PR DESCRIPTION
Set package.json to provide availability on NPM registry. 
See : https://www.npmjs.com/package/@antistatique/foehn

:warning: Because Foehn is not yet open, we publish it on a private Antistatique module. **Don't forget to grant acces to users and `npm login` before installing** !
