### PR TITLE
Adds logo height

### DIFF
--- a/assets/sass/molecules/_logo-etat.scss
+++ b/assets/sass/molecules/_logo-etat.scss
@@ -29,6 +29,7 @@
 
   > img {
     width: 10em;
+    height: 1.4em;
   }
 
   /* add the green underline */


### PR DESCRIPTION
## Description
- Fixes the overlapping height of the logo on IE11 by setting the height.
- Closes #402