### PR TITLE
Move and restyle back-to-top-btn in domain list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Move back to top button in domain list
 - Change style of back to top button in domain list
+- Visually hide headings "Accès direct" in domain page
+- Change list style of "Accès direct" in domain page
 
 ## [0.11.0]
 

--- a/assets/components/organisms/domains-list.html.swig
+++ b/assets/components/organisms/domains-list.html.swig
@@ -6,12 +6,13 @@ wrapper: container
 notes: |
 ---
 {% for domain_id, domain in data.domains.topics %}
+<div>
 <div class="row mt-3">
   <div class="col-md-4">
     <h2 id="{{ domain_id }}">{{ domain.name }}</h2>
-    <h3 id="acces-direct-{{ domain }}">Accès direct <span class="sr-only">{{ domain }}</span></h3>
-    <nav class="vd-bg-pattern-green p-1" aria-labelledby="acces-direct-{{ domain }}">
-      <ul class="nav vd-list-boxed">
+    <h3 id="acces-direct-{{ domain }}" class="sr-only">Accès direct {{ domain }}</h3>
+    <nav class="p-1" aria-labelledby="acces-direct-{{ domain }}">
+      <ul class="vd-list-links">
         <li class="nav-item"><a href="#" class="nav-link">Lorem ipsum dolor.</a></li>
         <li class="nav-item"><a href="#" class="nav-link">Lorem ipsum dolor.</a></li>
         <li class="nav-item"><a href="#" class="nav-link">Lorem ipsum dolor.</a></li>
@@ -32,5 +33,6 @@ notes: |
 </p>
 {% if ! loop.last %}
 <hr class="vd-separator vd-separator-green-pattern vd-separator-wide mt-3">
+</div>
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Move the back to top button at the bottom of each domain see #449

## Motivation and Context
- close #449
- close #488

## How Has This Been Tested?
`$ gulp` = 👌 

## Screenshots:

### Desktop
![napkin 3 06 12 16 a 11 40 38 am](https://cloud.githubusercontent.com/assets/611234/20922540/c03bfe72-bba8-11e6-9cff-bc3fe9f3c550.png)

### Mobile
![napkin 3 06 12 16 a 11 41 40 am](https://cloud.githubusercontent.com/assets/611234/20922569/e5499526-bba8-11e6-830c-7c2a2cefb908.png)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply.   
     If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I added this change in [CHANGELOG.md](https://github.com/DSI-VD/foehn/blob/master/CHANGELOG.md)

