### PR TITLE
CCWEB-10279 Fix logo-etat--default accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Changed
+- Fix `@logo-etat--default` accessibility by removing `aria-labelledby` and
+  adding `title` attribut
 - Add sr-only title to `@nav-side`
 - Replace `.text-muted` class with `.text-secondary`
 - Replace `.bg-inverse` class with `.bg-dark`

--- a/src/components/02-molecules/media/logo-etat/logo-etat.html
+++ b/src/components/02-molecules/media/logo-etat/logo-etat.html
@@ -1,4 +1,6 @@
-<a href="../accueil" class="vd-logo" aria-labelledby="aria-vd-logo">
+<a href="../accueil" 
+   class="vd-logo" 
+   title="Aller à la page d'accueil du Site du Canton de Vaud">
   {%- if blason -%}
   <div class="vd-logo__blason">
     <img src="{{ '/assets/svg/logo/logo.svg' | path }}" class="img-fluid d-none d-md-block" alt="Logo du canton de Vaud" />


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
When checking a11y with [a11y](https://github.com/addyosmani/a11y), here's the result:

```shell
$ a11y http://localhost:3000/components/preview/logo-etat--default

  ✖ ARIA state and property values must be valid

  body > .vd-logo


  ✔ This element does not support ARIA roles, states and properties
  ✔ This element has an invalid ARIA attribute
````

The `aria.labeledby` attribut reference an id that doesn't exist.

## Motivation and Context
http://issuetracker.etat-de-vaud.ch/outils/jira/browse/CCWEB-10279

## How Has This Been Tested?
```shell
$ a11y http://localhost:3000/components/preview/logo-etat--default
````

```shell
$ a11y http://localhost:3000/components/preview/accueil.html
````

```shell
$ npm start
```
## Screenshots (if appropriate):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply.   
     If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My changes meet the [AA level of conformance](https://www.w3.org/TR/WCAG20/) in terms of accessibility.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I added this change in [CHANGELOG.md](https://github.com/DSI-VD/foehn/blob/master/CHANGELOG.md)
